### PR TITLE
Fix/fix reader enconding

### DIFF
--- a/meta_quest_teleop/reader.py
+++ b/meta_quest_teleop/reader.py
@@ -633,10 +633,10 @@ class MetaQuestReader:
         Args:
             connection: Connection to read from.
         """
-        file_obj = connection.socket.makefile()
+        file_obj = connection.socket.makefile(mode="rb", buffering=1024)
         while self.running:
             try:
-                line = file_obj.readline().strip()
+                line = file_obj.readline().decode("utf-8", errors="replace").strip()
                 data = self.extract_data(line)
                 if data:
                     transforms, buttons = MetaQuestReader.process_data(data)


### PR DESCRIPTION
reader was always expecting utf-8 and sometimes meta quest sends shorter packets so it causes  Unicode decoding error. this filters it out and replaces it with a log to notify the users so it doesn't break silently and continues to receive other messages after. 